### PR TITLE
Use Modelfile for Ollama summarizer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ graph TD
 
 * **Language:** Rust 1.89
 * **DB:** Postgres (via sqlx), tables: topics, posts, topic_summaries_llm
-* **LLM:** Ollama HTTP API /api/chat (Qwen2.5 latest or equivalent)
+* **LLM:** Ollama HTTP API /api/chat (Qwen2.5 latest or equivalent); system prompt and default parameters defined in `Modelfile`
 * **Timeouts/Backoff:** HTTP 120s total; exponential backoff for LLM calls; outer task timeout 120s
 * **Chunking:** first‑page posts only (vertical slice), char‑safe chunk ≤ 1.8k
 * **Summaries:** JSON → rendered into text; prefer LLM, fallback to heuristic if present
@@ -101,7 +101,7 @@ graph TD
 
 **Purpose:** Create concise, factual summaries with citations.
 
-**Runtime:** Ollama → `/api/chat` with keep_alive: "5m"; model from LLM_MODEL (e.g., qwen2.5:latest).
+**Runtime:** Ollama → `/api/chat` with keep_alive: "5m"; model from LLM_MODEL (e.g., qwen2.5:latest). System prompt and default inference parameters are baked into the repo's `Modelfile`; requests only send user prompts.
 
 **Providers:** Only the local Ollama endpoint is supported; the old multi-provider `llm` module has been removed.
 

--- a/Modelfile
+++ b/Modelfile
@@ -1,0 +1,21 @@
+FROM qwen2.5:latest
+
+# System prompt used for all summaries
+SYSTEM """
+You are a technical note-taker. Output a one-line headline and 3–6 factual bullets.
+Include dates/numbers from the text. No speculation. If off-topic/banter, say: 'Meta: off-topic'.
+"""
+
+# Default inference parameters
+PARAMETER temperature 0.2
+PARAMETER num_ctx 8192
+PARAMETER top_p 0.9
+PARAMETER repeat_penalty 1.05
+
+# The user prompt already requests strict JSON output, but the template reminds the model
+TEMPLATE """
+{{- if .System }}{{ .System }}{{ end }}
+{{- range .Messages }}{{ .Content }}{{ end }}
+
+Respond ONLY with valid JSON.
+"""

--- a/README.md
+++ b/README.md
@@ -47,3 +47,15 @@ graph TD
   S -.-> TR
 ```
 
+## Ollama model
+
+The repo includes a `Modelfile` that bakes in the summarizer's system prompt and default inference parameters.
+Build the model once and point `LLM_MODEL` at it:
+
+```bash
+ollama create zc-forum-summarizer -f Modelfile
+export LLM_MODEL=zc-forum-summarizer
+```
+
+You can tweak the `Modelfile` to experiment with other options like templates or adapters.
+


### PR DESCRIPTION
## Summary
- move Ollama system prompt and inference parameters into a repository Modelfile
- simplify summarizer to rely on Modelfile defaults and count system prompt tokens
- document custom model usage and Modelfile location

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: no cached sqlx data)*
- `cargo test --all-features` *(fails: no cached sqlx data)*

------
https://chatgpt.com/codex/tasks/task_e_68b12a9222c4832dbff7bf7022d06551