### PR TITLE
Add basic tests and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.89
+          components: rustfmt, clippy
+      - name: Install cargo-nextest
+        run: cargo install cargo-nextest
+      - name: Format
+        run: cargo fmt --all -- --check
+      - name: Clippy
+        run: cargo clippy --all-features --lib -- -D warnings
+      - name: Tests
+        run: cargo nextest run --all-features --lib

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,12 @@ graph TD
 
 **Exit hook:** `teardown` runs when leaving nix develop.
 
+## 8) CI
+
+**Purpose:** Lint and test on pushes and PRs.
+
+**Workflow:** `.github/workflows/ci.yml` runs `cargo fmt --all -- --check`, `cargo clippy --all-features --lib -- -D warnings`, and `cargo nextest run --all-features --lib`.
+
 ## Configuration
 
 **Environment variables**

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,104 @@
+use once_cell::sync::Lazy;
+use regex::Regex;
+use sha2::{Digest, Sha256};
+
+static TAGS_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?is)<[^>]*>").unwrap());
+
+pub fn strip_tags_fast(html: &str) -> String {
+    let no_tags = TAGS_RE.replace_all(html, " ");
+    squeeze_ws(no_tags.trim())
+}
+
+pub fn squeeze_ws(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut prev_space = false;
+    for ch in s.chars() {
+        if ch.is_whitespace() {
+            if !prev_space {
+                out.push(' ');
+                prev_space = true;
+            }
+        } else {
+            out.push(ch);
+            prev_space = false;
+        }
+    }
+    out
+}
+
+pub fn take_prefix_chars(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        return s.to_string();
+    }
+    let mut cut = 0usize;
+    for (idx, _) in s.char_indices() {
+        if idx <= max {
+            cut = idx;
+        } else {
+            break;
+        }
+    }
+    s[..cut].to_string()
+}
+
+pub fn make_chunk(lines: &[String], max_chars: usize) -> String {
+    let mut cur = String::new();
+    for l in lines {
+        if cur.len() + l.len() + 1 > max_chars {
+            let remain = max_chars.saturating_sub(cur.len());
+            if remain > 0 {
+                cur.push_str(&take_prefix_chars(l, remain));
+            }
+            break;
+        }
+        if !l.is_empty() {
+            cur.push_str(l);
+            cur.push('\n');
+        }
+    }
+    cur
+}
+
+pub fn prompt_hash(topic_id: i64, model: &str, prompt: &str) -> String {
+    let mut h = Sha256::new();
+    h.update(model.as_bytes());
+    h.update(b"\n");
+    h.update(topic_id.to_be_bytes());
+    h.update(b"\n");
+    h.update(prompt.as_bytes());
+    format!("{:x}", h.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn squeeze_ws_collapses_whitespace() {
+        let s = "Hello   world \n\n test";
+        assert_eq!(squeeze_ws(s), "Hello world test");
+    }
+
+    #[test]
+    fn strip_tags_fast_removes_html_and_normalizes_space() {
+        let html = "<p>Hello <b>world</b></p>\n<div>Rust lang</div>";
+        assert_eq!(strip_tags_fast(html), "Hello world Rust lang");
+    }
+
+    #[test]
+    fn take_prefix_chars_handles_utf8_boundaries() {
+        assert_eq!(take_prefix_chars("a🐱b", 5), "a🐱");
+        assert_eq!(take_prefix_chars("a🐱b", 3), "a");
+    }
+
+    #[test]
+    fn make_chunk_truncates_without_splitting_chars() {
+        let lines = vec![
+            "12345".to_string(),
+            "67890".to_string(),
+            "abcde".to_string(),
+        ];
+        let chunk = make_chunk(&lines, 11);
+        assert_eq!(chunk, "12345\n67890");
+    }
+}


### PR DESCRIPTION
## Summary
- factor out string utilities into a library module with unit tests
- add GitHub Actions workflow running fmt, clippy and tests
- document CI expectations in AGENTS.md

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-features --lib -- -D warnings`
- `cargo nextest run --all-features --lib`


------
https://chatgpt.com/codex/tasks/task_e_68b12a9fe324832db4c27a472bf825a0