### PR TITLE
process topics concurrently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,6 +480,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -524,6 +539,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -541,8 +567,10 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -2847,6 +2875,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "backoff",
+ "futures",
  "once_cell",
  "regex",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ once_cell = "1.21.3"
 backoff = { version = "0.4", features = ["tokio"] }
 sha2 = "0.10"
 tiktoken-rs = "0.7"
+futures = "0.3"


### PR DESCRIPTION
## Summary
- process forum topics concurrently with `stream::iter` and a bounded `buffer_unordered`
- add `futures` dependency and a concurrency limit

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-features --lib -- -D warnings`
- `cargo nextest run --all-features --lib`


------
https://chatgpt.com/codex/tasks/task_e_68b1c2e4b698832da0c37e0ff0562b37