### PR TITLE
Log warm-up failure in summarization

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -69,9 +69,12 @@ async fn main() -> Result<()> {
     let ollama_base =
         std::env::var("OLLAMA_BASE_URL").unwrap_or_else(|_| OLLAMA_DEFAULT_BASE.to_string());
 
-    // Warm up the model once (ignore the result).
+    // Warm up the model once and warn if it fails.
     let warm_prompt = build_prompt("warmup", "warmup");
-    let _ = summarize_with_ollama(&client, &ollama_base, &model, &warm_prompt).await;
+    let warmup_res = summarize_with_ollama(&client, &ollama_base, &model, &warm_prompt).await;
+    if let Err(e) = warmup_res {
+        warn!("Warm-up summarize_with_ollama failed: {e}");
+    }
 
     // Fetch latest list of topics
     let latest: Latest = fetch_latest(&client).await?;


### PR DESCRIPTION
## Summary
- warn if the warm-up `summarize_with_ollama` call fails

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-features --lib -- -D warnings`
- `cargo nextest run --all-features --lib`


------
https://chatgpt.com/codex/tasks/task_e_68b1c83652e4832d819b07e63e16db8a