### PR TITLE
Truncate raw LLM output in error logs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,7 +121,7 @@ whitespace squeeze; label lines as `[post:<id> @ <iso8601>]`.
 
 **Outputs → DB:** topic_summaries_llm(topic_id, summary, model, prompt_hash, input_tokens, output_tokens, updated_at).
 
-**Failure Handling:** timeout/HTTP error → warn and continue; process remains healthy.
+**Failure Handling:** timeout/HTTP error → warn and continue; JSON parse errors log the raw LLM output truncated to 200 chars with an ellipsis; process remains healthy.
 
 ## 5) Storage
 


### PR DESCRIPTION
## Summary
- truncate Ollama JSON parse errors to 200 characters and add ellipsis when truncated
- cover truncation behavior with test
- document truncated logging behavior

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-features --lib -- -D warnings`
- `cargo nextest run --all-features --lib`
- `cargo nextest run --all-features --test ollama` *(fails: `set DATABASE_URL` to use query macros online)*

------
https://chatgpt.com/codex/tasks/task_e_68b2126373fc832db4aadaf4a16fbb8a