### PR TITLE
Add daily digest generator and pages workflow

### DIFF
--- a/.github/workflows/digest.yml
+++ b/.github/workflows/digest.yml
@@ -30,7 +30,7 @@ jobs:
           LLM_MODEL: qwen2.5:latest
           OLLAMA_BASE_URL: http://127.0.0.1:11434
         run: |
-          cargo run --release || true
+          cargo run --release
       - name: Generate digest
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/zc_forum

--- a/.github/workflows/digest.yml
+++ b/.github/workflows/digest.yml
@@ -1,0 +1,53 @@
+name: Daily Digest
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.89
+      - name: Install Postgres
+        run: sudo apt-get update && sudo apt-get install -y postgresql
+      - name: Start Postgres
+        run: sudo service postgresql start
+      - name: Create database
+        run: sudo -u postgres createdb zc_forum || true
+      - name: Run ETL
+        env:
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/zc_forum
+          LLM_MODEL: qwen2.5:latest
+          OLLAMA_BASE_URL: http://127.0.0.1:11434
+        run: |
+          cargo run --release || true
+      - name: Generate digest
+        env:
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/zc_forum
+        run: cargo run --release --bin digest
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: public
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - name: Deploy to Pages
+        id: deploy
+        uses: actions/deploy-pages@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,3 +202,12 @@ Local inference by default (Ollama). No user secrets in prompts.
 Only public forum content is processed; avoid logging raw post bodies at `INFO`.
 
 Consider per‑provider allowlist if you later add remote LLMs.
+
+## 9) Daily Digest
+
+**Purpose:** Publish an HTML digest of forum topics updated in the last 24 hours.
+
+**Runtime:** The `digest` binary queries recent topics and writes `public/index.html` with existing LLM summaries.
+
+**Workflow:** `.github/workflows/digest.yml` runs the ETL, generates the digest page, and deploys it to GitHub Pages on a daily schedule or manual trigger.
+

--- a/src/bin/digest.rs
+++ b/src/bin/digest.rs
@@ -1,0 +1,57 @@
+use anyhow::Result;
+use serde::Deserialize;
+use sqlx::{PgPool, Row};
+use time::OffsetDateTime;
+
+#[derive(Deserialize)]
+struct LlmSummary {
+    headline: String,
+    bullets: Vec<String>,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let pool = PgPool::connect(&std::env::var("DATABASE_URL")?).await?;
+
+    // fetch topics with activity in last 24 hours
+    let rows = sqlx::query(
+        r#"SELECT t.id, t.title, ts.summary, MAX(p.created_at) AS last_post
+            FROM topics t
+            JOIN posts p ON t.id = p.topic_id
+            LEFT JOIN topic_summaries_llm ts ON t.id = ts.topic_id
+            WHERE p.created_at >= now() - interval '1 day'
+            GROUP BY t.id, t.title, ts.summary
+            ORDER BY last_post DESC"#,
+    )
+    .fetch_all(&pool)
+    .await?;
+
+    let mut html = String::new();
+    html.push_str("<!DOCTYPE html><html><head><meta charset=\"utf-8\"><title>Zcash Forum Digest</title></head><body>");
+    html.push_str(&format!(
+        "<h1>Zcash Forum Digest for {}</h1>",
+        OffsetDateTime::now_utc().date()
+    ));
+
+    for row in rows {
+        let title: String = row.get("title");
+        let summary_json: Option<String> = row.get("summary");
+        html.push_str(&format!("<h2>{}</h2>", title));
+        if let Some(js) = summary_json {
+            if let Ok(s) = serde_json::from_str::<LlmSummary>(&js) {
+                if !s.bullets.is_empty() {
+                    html.push_str("<ul>");
+                    for b in s.bullets {
+                        html.push_str(&format!("<li>{}</li>", b));
+                    }
+                    html.push_str("</ul>");
+                }
+            }
+        }
+    }
+
+    html.push_str("</body></html>");
+    std::fs::create_dir_all("public")?;
+    std::fs::write("public/index.html", html)?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add `digest` binary to render last-day topic summaries into `public/index.html`
- document new daily digest component
- publish digest via scheduled GitHub Pages workflow

## Testing
- `cargo fmt --all`
- `cargo clippy --all-features --lib`
- `OLLAMA_MAX_ELAPSED_SECS=1 cargo nextest run --all-features --lib`


------
https://chatgpt.com/codex/tasks/task_e_68b2149b367c832d93a89a50f71b8a7b