### PR TITLE
Count Unicode characters when chunking

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,26 +113,21 @@ pub fn squeeze_ws(s: &str) -> String {
     out
 }
 
-pub fn take_prefix_chars(s: &str, max: usize) -> String {
-    if s.len() <= max {
+pub fn take_prefix_chars(s: &str, max_chars: usize) -> String {
+    let total = s.chars().count();
+    if total <= max_chars {
         return s.to_string();
     }
-    let mut cut = 0usize;
-    for (idx, _) in s.char_indices() {
-        if idx <= max {
-            cut = idx;
-        } else {
-            break;
-        }
-    }
-    s[..cut].to_string()
+    s.chars().take(max_chars).collect()
 }
 
 pub fn make_chunk(lines: &[String], max_chars: usize) -> String {
     let mut cur = String::new();
+    let mut cur_chars = 0usize;
     for l in lines {
-        if cur.len() + l.len() + 1 > max_chars {
-            let remain = max_chars.saturating_sub(cur.len());
+        let l_chars = l.chars().count();
+        if cur_chars + l_chars + 1 > max_chars {
+            let remain = max_chars.saturating_sub(cur_chars);
             if remain > 0 {
                 cur.push_str(&take_prefix_chars(l, remain));
             }
@@ -141,6 +136,7 @@ pub fn make_chunk(lines: &[String], max_chars: usize) -> String {
         if !l.is_empty() {
             cur.push_str(l);
             cur.push('\n');
+            cur_chars += l_chars + 1; // account for newline
         }
     }
     cur
@@ -225,8 +221,8 @@ mod tests {
 
     #[test]
     fn take_prefix_chars_handles_utf8_boundaries() {
-        assert_eq!(take_prefix_chars("a🐱b", 5), "a🐱");
-        assert_eq!(take_prefix_chars("a🐱b", 3), "a");
+        assert_eq!(take_prefix_chars("a🐱b", 2), "a🐱");
+        assert_eq!(take_prefix_chars("a🐱b", 1), "a");
     }
 
     #[test]

--- a/tests/chunk_chars.rs
+++ b/tests/chunk_chars.rs
@@ -1,0 +1,15 @@
+use zc_forum_etl::{make_chunk, take_prefix_chars};
+
+#[test]
+fn take_prefix_chars_handles_multibyte() {
+    let s = "é😊ño"; // 4 characters
+    assert_eq!(take_prefix_chars(s, 2), "é😊");
+}
+
+#[test]
+fn make_chunk_counts_chars() {
+    let lines = vec!["é".to_string(), "😀".to_string()];
+    let chunk = make_chunk(&lines, 3);
+    assert_eq!(chunk, "é\n😀");
+    assert_eq!(chunk.chars().count(), 3);
+}

--- a/tests/db_text_prep.rs
+++ b/tests/db_text_prep.rs
@@ -55,7 +55,7 @@ async fn load_plain_lines_orders_and_strips(pool: PgPool) -> Result<()> {
 
     // optional: ensure chunking respects length limit
     let chunk = make_chunk(&lines, 80);
-    assert!(chunk.len() <= 80);
+    assert!(chunk.chars().count() <= 80);
 
     // ensure actual timestamps in formatted string
     let ts_old = t_old.format(&Rfc3339)?;


### PR DESCRIPTION
## Summary
- Track character counts in `take_prefix_chars` and `make_chunk` to avoid splitting multi-byte characters
- Enforce chunk limits by counting characters instead of bytes
- Add tests for Unicode handling and update existing chunk length check

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-features --lib -- -D warnings`
- `cargo nextest run --all-features --lib`
- `cargo test --all-features` *(fails: set `DATABASE_URL` to use query macros online)*

------
https://chatgpt.com/codex/tasks/task_e_68b2168f91f8832d8cc9082602c02df0