### PR TITLE
Install and build Ollama model in digest workflow

### DIFF
--- a/.github/workflows/digest.yml
+++ b/.github/workflows/digest.yml
@@ -31,6 +31,17 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.89
+      - name: Install and start Ollama
+        run: |
+          curl -L https://ollama.ai/install.sh | sh
+          ollama serve >/tmp/ollama.log 2>&1 &
+          until curl -s http://127.0.0.1:11434/api/version >/dev/null; do
+            sleep 1
+          done
+      - name: Build Ollama model
+        run: |
+          ollama create zc-forum-summarizer -f Modelfile
+          ollama run zc-forum-summarizer -p "ping" >/tmp/ollama-warmup.log
       - name: Wait for DB
         run: |
           # Wait for PostgreSQL to become ready, with exponential backoff (max 60s)
@@ -49,7 +60,7 @@ jobs:
       - name: Run ETL
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/zc_forum
-          LLM_MODEL: qwen2.5:latest
+          LLM_MODEL: zc-forum-summarizer
           OLLAMA_BASE_URL: http://127.0.0.1:11434
         run: |
           cargo run --release --bin zc-forum-etl

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,5 +209,5 @@ Consider per‑provider allowlist if you later add remote LLMs.
 
 **Runtime:** The `digest` binary queries recent topics and writes `public/index.html` with existing LLM summaries.
 
-**Workflow:** `.github/workflows/digest.yml` runs the ETL, generates the digest page, and deploys it to GitHub Pages on a daily schedule or manual trigger.
+**Workflow:** `.github/workflows/digest.yml` installs and starts Ollama, builds the `zc-forum-summarizer` model from `Modelfile`, runs the ETL, generates the digest page, and deploys it to GitHub Pages on a daily schedule or manual trigger.
 


### PR DESCRIPTION
## Summary
- install Ollama and start the server in the digest workflow
- build the zc-forum-summarizer model and warm it up
- document digest workflow now building the local model

## Testing
- `cargo fmt --all -- --check`
- `cargo test` *(fails: no cached data for SQLx queries – requires database or `cargo sqlx prepare`)*

------
https://chatgpt.com/codex/tasks/task_e_68b31f684344832dac9819d90e630d91