### PR TITLE
Process topics sequentially to avoid CI timeouts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@ graph TD
 * **DB:** Postgres (via sqlx), tables: topics, posts, topic_summaries_llm
 * **LLM:** Ollama HTTP API /api/chat (Qwen2.5 latest or equivalent)
 * **Timeouts/Backoff:** HTTP 120s total; exponential backoff for LLM calls; outer task timeout 120s
+* **Concurrency:** topics are processed sequentially (TOPIC_CONCURRENCY = 1) to stay within GitHub Actions timeouts
 * **Chunking:** first‑page posts only (vertical slice), char‑safe chunk ≤ 1.8k
 * **Summaries:** JSON → rendered into text; prefer LLM, fallback to heuristic if present
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ Environment variables:
 - `LLM_MODEL`: Ollama model tag (default: `qwen2.5:latest`. For tuned prompts, it is recommended to build and use `zc-forum-summarizer` from the provided `Modelfile`.)
 - `OLLAMA_BASE_URL`: base URL for the Ollama API (default `http://127.0.0.1:11434`)
 
+The ETL processes topics sequentially to avoid timeouts on GitHub Actions.
+Adjust `TOPIC_CONCURRENCY` in `src/main.rs` if you need more parallelism locally.
+
 The `Modelfile` embeds the system prompt and default runtime parameters. Adjust it to tweak
 `temperature`, `num_ctx`, or other options and recreate the model. Requests send only the
 thread excerpt; formatting rules live in the model.

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use zc_forum_etl::{
 
 const CHUNK_MAX_CHARS: usize = 1_800; // keep prompt small for local models
 const SUM_TIMEOUT_SECS: u64 = 240; // wrap around our own retry/HTTP timeouts
-const TOPIC_CONCURRENCY: usize = 5; // limit concurrent topic processing
+const TOPIC_CONCURRENCY: usize = 1; // process topics sequentially to avoid CI timeouts
 
 const OLLAMA_DEFAULT_BASE: &str = "http://127.0.0.1:11434";
 
@@ -81,6 +81,8 @@ async fn main() -> Result<()> {
     info!("Fetched {} topics", latest.topic_list.topics.len());
 
     let topics = latest.topic_list.topics;
+    // Sequential processing keeps CI runs within timeouts. Adjust
+    // `TOPIC_CONCURRENCY` if parallelism is desired locally.
     stream::iter(topics.into_iter())
         .map(|topic| {
             let client = client.clone();


### PR DESCRIPTION
## Summary
- reduce topic concurrency to 1 and comment sequential rationale
- document sequential processing in AGENTS.md and README

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-features --lib -- -D warnings`
- `cargo nextest run --all-features --lib`


------
https://chatgpt.com/codex/tasks/task_e_68b32d8657dc832da14a6eccc8c5d40c