### PR TITLE
refactor: add posts_to_chunk

### DIFF
--- a/tests/chunk_chars.rs
+++ b/tests/chunk_chars.rs
@@ -1,4 +1,5 @@
-use zc_forum_etl::{make_chunk, take_prefix_chars};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+use zc_forum_etl::{Post, posts_to_chunk, take_prefix_chars};
 
 #[test]
 fn take_prefix_chars_handles_multibyte() {
@@ -7,9 +8,24 @@ fn take_prefix_chars_handles_multibyte() {
 }
 
 #[test]
-fn make_chunk_counts_chars() {
-    let lines = vec!["é".to_string(), "😀".to_string()];
-    let chunk = make_chunk(&lines, 3);
-    assert_eq!(chunk, "é\n😀");
-    assert_eq!(chunk.chars().count(), 3);
+fn posts_to_chunk_counts_chars() {
+    let ts = OffsetDateTime::UNIX_EPOCH;
+    let posts = vec![
+        Post {
+            id: 1,
+            cooked: "<p>é</p>".to_string(),
+            created_at: ts,
+        },
+        Post {
+            id: 2,
+            cooked: "<p>😀</p>".to_string(),
+            created_at: ts,
+        },
+    ];
+    let ts_str = ts.format(&Rfc3339).unwrap();
+    let expected = format!("[post:1 @ {ts}] é\n[post:2 @ {ts}] 😀", ts = ts_str);
+    let max = expected.chars().count();
+    let chunk = posts_to_chunk(posts.iter(), max);
+    assert_eq!(chunk, expected);
+    assert_eq!(chunk.chars().count(), max);
 }


### PR DESCRIPTION
## Summary
- merge post formatting and chunking via `posts_to_chunk`
- call `posts_to_chunk` in main instead of line-based helpers
- update tests for new chunk function

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b46f2fa604832d9d9cf6e2bc08175b